### PR TITLE
 Add CORS configuration for frontend development

### DIFF
--- a/Dependencies.toml
+++ b/Dependencies.toml
@@ -263,7 +263,7 @@ dependencies = [
 [[package]]
 org = "ballerina"
 name = "oauth2"
-version = "2.14.0"
+version = "2.14.1"
 dependencies = [
 	{org = "ballerina", name = "cache"},
 	{org = "ballerina", name = "crypto"},
@@ -433,6 +433,7 @@ modules = [
 	{org = "nalaka", packageName = "service", moduleName = "service.auth"},
 	{org = "nalaka", packageName = "service", moduleName = "service.call"},
 	{org = "nalaka", packageName = "service", moduleName = "service.common"},
+	{org = "nalaka", packageName = "service", moduleName = "service.driver_management"},
 	{org = "nalaka", packageName = "service", moduleName = "service.firebase"},
 	{org = "nalaka", packageName = "service", moduleName = "service.firebase_auth"},
 	{org = "nalaka", packageName = "service", moduleName = "service.notification"},

--- a/modules/driver_management/driver_management.bal
+++ b/modules/driver_management/driver_management.bal
@@ -33,20 +33,21 @@ public function getDrivers() returns http:Response|error {
         
         string status = userData.hasKey("status") ? checkpanic userData.status.ensureType() : "pending";
 
-        // --- THE FINAL FIX: HANDLING THE TIMESTAMP CORRECTLY ---
+        // --- THIS IS THE FIX: ADDED THE EMAIL LOGIC ---
+        string email = userData.hasKey("email") ? checkpanic userData.email.ensureType() : "N/A";
+
+        // --- Date Handling Logic (already correct) ---
         string registeredDate = "N/A";
         if (userData.hasKey("createdAt") && userData.createdAt is map<json>) {
             map<json> tsMap = checkpanic userData.createdAt.ensureType();
             int seconds = checkpanic tsMap["_seconds"].ensureType();
-            
-            // Step 1: Create the Utc tuple directly from the seconds.
+
             time:Utc utcTime = [seconds, 0.0d];
 
-            // Step 2: Convert the Utc tuple to a calendar-based Civil record.
-            // This function should exist in your environment.
-            time:Civil civilTime = time:utcToCivil(utcTime);
 
-            // Step 3: Format the string. This part was already correct.
+            time:Civil civilTime = time:utcToCivil(utcTime);
+            
+
             registeredDate = string `${civilTime.year}-${civilTime.month.toString().padStart(2, "0")}-${civilTime.day.toString().padStart(2, "0")}`;
         }
 
@@ -69,6 +70,7 @@ public function getDrivers() returns http:Response|error {
         map<json> driverRecord = {
             id: id,
             name: name,
+            email: email, // --- THIS IS THE FIX: ADDED EMAIL TO THE RESPONSE ---
             vehicle: vehicle,
             registeredDate: registeredDate,
             status: status,

--- a/service.bal
+++ b/service.bal
@@ -20,8 +20,20 @@ import ballerina/log;
 
 
 
+// 1. Define the CORS configuration with the CORRECT port number.
+http:CorsConfig corsConfig = {
+    allowOrigins: ["http://localhost:3000"], // <-- THE FIX IS HERE
+    allowMethods: ["GET", "POST", "PUT", "DELETE", "OPTIONS"],
+    allowHeaders: ["Content-Type", "Authorization"]
+};
 
+// 2. Apply the CORS configuration using the @http:ServiceConfig annotation.
+@http:ServiceConfig {
+    cors: corsConfig
+}
 service /api on new http:Listener(9090) {
+
+    // --- All your resource functions go here ---
 
     resource function post register(@http:Payload json payload) returns http:Response|error {
         string accessToken = checkpanic firebase:generateAccessToken();


### PR DESCRIPTION
# Description
This pull request adds the necessary Cross-Origin Resource Sharing (CORS) configuration to the Ballerina backend service. 

This change is required to allow the frontend application, which runs on a different port (`http://localhost:3000`), to make API calls to the backend (`http://localhost:9090`) during local development without being blocked by the browser's Same-Origin Policy.

## Changes Made
- Added an `@http:ServiceConfig` annotation to the main `service /api` block in `service.bal`.
- Configured the CORS policy to allow origins from `http://localhost:3000`.
- Allowed common HTTP methods (GET, POST, etc.) and headers (Content-Type, Authorization).